### PR TITLE
Fix CI yarn and node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/node:18.4.0-browsers
+      - image: cimg/node:lts-browsers
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -35,6 +35,9 @@ jobs:
             sudo apt-get install -f;
 
       # install developer tools
+      - run:
+          name: Upgrade yarn
+          command: sudo npm install -g yarn@1.22.19
       - run: yarn install
 
       - save_cache:


### PR DESCRIPTION
## Summary
- bump CircleCI node image to `cimg/node:lts-browsers`
- install a newer yarn (1.22.19) before dependency installation

## Testing
- `yarn install` *(fails: network unavailable)*
- `yarn test` *(fails: yarn install did not run)*