### PR TITLE
Fix CI yarn and chrome installation issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/node:18.4.0-browsers
+      - image: cimg/node:lts-browsers
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -25,16 +25,10 @@ jobs:
           - v1-dependencies-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
-
-      - run:
-          # add library mainly for test (though browser test is not done. just for using Karma.) 
-          name: add libraries
-          command: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            sudo dpkg -i google-chrome-stable_current_amd64.deb;
-            sudo apt-get install -f;
-
       # install developer tools
+      - run:
+          name: Upgrade yarn
+          command: sudo npm install -g yarn@1.22.19
       - run: yarn install
 
       - save_cache:


### PR DESCRIPTION
## Summary
- bump CircleCI node image to `cimg/node:lts-browsers`
- upgrade Yarn to 1.22.19 in CI
- remove manual Chrome install step that caused dependency errors

## Testing
- `yarn install --immutable --immutable-cache --check-cache` *(fails: network unavailable)*
- `yarn test` *(fails: dependencies were not installed)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.