### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+      - name: Set CHROME_BIN env
+        run: echo "CHROME_BIN=$(which google-chrome)" >> $GITHUB_ENV
+      - name: Run tests
+        run: yarn test

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This extension is by MIT License
 
 ## CI
 
-using CircleCI 2.0
+CI runs on GitHub Actions. It installs Chrome and sets `CHROME_BIN` so Karma can launch `ChromeHeadless`.
 
 Packed extension zip would be uploaded on artifact section on the successful build.
 
@@ -107,8 +107,8 @@ cf. [Is it possible to auto\-update a chrome extension published on the chrome w
 
 requires external library and/or API for this.
 
- * [Wikipedia í—pŠ¿šˆê——(“Ç‚İ‚ ‚è)](https://ja.wikipedia.org/wiki/%E5%B8%B8%E7%94%A8%E6%BC%A2%E5%AD%97%E4%B8%80%E8%A6%A7)
- * [í—pŠ¿š•\ on github by someone](https://github.com/cjkvi/cjkvi-tables)
+ * [Wikipedia å¸¸ç”¨æ¼¢å­—ä¸€è¦§(èª­ã¿ã‚ã‚Š)](https://ja.wikipedia.org/wiki/%E5%B8%B8%E7%94%A8%E6%BC%A2%E5%AD%97%E4%B8%80%E8%A6%A7)
+ * [å¸¸ç”¨æ¼¢å­—è¡¨ on github by someone](https://github.com/cjkvi/cjkvi-tables)
 
 ## ToDo: expand to Middle and High-school
 


### PR DESCRIPTION
## Summary
- run CI using GitHub Actions to install Chrome and run tests
- update README to describe new CI system

## Testing
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*