### PR TITLE
Add packaging to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,21 @@ jobs:
         uses: browser-actions/setup-chrome@v1
       - name: Set CHROME_BIN env
         run: echo "CHROME_BIN=$(which google-chrome)" >> $GITHUB_ENV
+      - name: Run lint
+        run: yarn lint
       - name: Run tests
         run: yarn test
+      - name: Pack extension
+        run: yarn pack
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: extension
+          path: extension.zip
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: extension.zip
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ CI runs on GitHub Actions. It installs Chrome and sets `CHROME_BIN` so Karma can
 The workflow also runs `yarn scrape` to fetch kanji data before tests.
 
 Packed extension zip would be uploaded on artifact section on the successful build.
+When a tag starting with `v` is pushed, the workflow creates a numbered GitHub release with `extension.zip` attached.
 
 ## deployment
 


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to lint, test, pack and release
- document the release process in the README

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*
- `yarn test` *(fails: package isn't in lockfile)*