### PR TITLE
Add packaging to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,24 @@ jobs:
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v1
       - name: Set CHROME_BIN env
-        run: echo "CHROME_BIN=$(which google-chrome)" >> $GITHUB_ENV
+        run: |
+          CHROME_PATH="$(which google-chrome-stable || which google-chrome || which chromium-browser)"
+          echo "CHROME_BIN=$CHROME_PATH" >> $GITHUB_ENV
+      - name: Run lint
+        run: yarn lint
       - name: Run tests
         run: yarn test
+      - name: Pack extension
+        run: yarn pack
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension
+          path: extension.zip
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: extension.zip
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ This extension is by MIT License
 CI runs on GitHub Actions. It installs Chrome and sets `CHROME_BIN` so Karma can launch `ChromeHeadless`.
 The workflow also runs `yarn scrape` to fetch kanji data before tests.
 
-Packed extension zip would be uploaded on artifact section on the successful build.
+The workflow packs the extension into `extension.zip` which is uploaded as a build artifact.
+When a tag starting with `v` is pushed, the same zip file is attached to a numbered GitHub release.
 
 ## deployment
 


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to lint, test, pack and release
- document the release process in the README

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*
- `yarn test` *(fails: package isn't in lockfile)*
