### PR TITLE
Add packaging to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,21 @@ jobs:
         uses: browser-actions/setup-chrome@v1
       - name: Set CHROME_BIN env
         run: echo "CHROME_BIN=$(which google-chrome)" >> $GITHUB_ENV
+      - name: Run lint
+        run: yarn lint
       - name: Run tests
         run: yarn test
+      - name: Pack extension
+        run: yarn pack
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension
+          path: extension.zip
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: extension.zip
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ This extension is by MIT License
 CI runs on GitHub Actions. It installs Chrome and sets `CHROME_BIN` so Karma can launch `ChromeHeadless`.
 The workflow also runs `yarn scrape` to fetch kanji data before tests.
 
-Packed extension zip would be uploaded on artifact section on the successful build.
+After a successful build, the workflow uploads `extension.zip` as a build artifact.
+When a tag starting with `v` is pushed, the workflow creates a numbered GitHub release with `extension.zip` attached.
 
 ## deployment
 


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to lint, test, pack and release using latest upload-artifact
- document artifact upload and numbered releases in the README

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*
- `yarn test` *(fails: package isn't in lockfile)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.