### PR TITLE
Add packaging to CI workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
   parserOptions: {
     sourceType: "module",
   },
-  "plugins": ["@babel"],
   rules: {
     "indent": ["error", 4],
     "linebreak-style": ["error", "unix"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,22 @@ jobs:
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v1
       - name: Set CHROME_BIN env
-        run: echo "CHROME_BIN=$(which google-chrome)" >> $GITHUB_ENV
+        run: echo "CHROME_BIN=$(which google-chrome google-chrome-stable chromium-browser chromium | head -n 1)" >> $GITHUB_ENV
+      - name: Run lint
+        run: yarn lint
       - name: Run tests
         run: yarn test
+      - name: Pack extension
+        run: yarn pack
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension
+          path: extension.zip
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: extension.zip
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ CI runs on GitHub Actions. It installs Chrome and sets `CHROME_BIN` so Karma can
 The workflow also runs `yarn scrape` to fetch kanji data before tests.
 
 Packed extension zip would be uploaded on artifact section on the successful build.
+When a tag starting with `v` is pushed, the workflow creates a numbered GitHub release with `extension.zip` attached.
 
 ## deployment
 


### PR DESCRIPTION
## Summary
- update CI workflow to lint, test, pack and release
- document the release process in the README
- fix CI: set `CHROME_BIN` more robustly and use `actions/upload-artifact@v4`
- remove unused `@babel` ESLint plugin

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*
- `yarn test` *(fails: package isn't in lockfile)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.