### PR TITLE
Fix workflow packaging step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: yarn test
       - name: Pack extension
-        run: yarn pack
+        run: yarn run pack
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This takes kanji list from Mext website, format them in JavaScript file to be im
 ## packaging
 
 ~~~
-$ yarn pack
+$ yarn run pack
 ~~~
 
 This only packs neccessary files for deployment on Extension stores. (currently for Chrome store)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "beautify": "eslint --fix scripts/*.js && stylelint --fix css/*.css",
     "check_firefox_compatibility": "wemf ./manifest.json --validate",
     "test": "karma start karma.conf.js",
-    "pack": "zip -r extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
+    "prepack": "zip -r extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
+    "pack": "yarn run prepack",
     "update_package_json": "node_modules/.bin/syncyarnlock -s -k"
   },
   "dependencies": {},


### PR DESCRIPTION
## Summary
- update README to use `yarn run pack`
- add `prepack` script so that `yarn run pack` zips extension
- call `yarn run pack` in CI

## Testing
- `yarn lint` *(fails: package isn't installed)*
- `yarn test` *(fails: package isn't installed)*