### PR TITLE
Fix tests by documenting CHROME_BIN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: yarn test
       - name: Pack extension
-        run: yarn pack
+        run: yarn run pack
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ $ yarn test
 The above command invokes Karma test runner. Karma auto-requires js modules (like as Chrome Extension env does) so test code can call them.
 
 Karma always comes with (headless) browser, which I do not use now. Test runner without client browser would fit better for this project but I could not find.
+If you see an error about `ChromeHeadless` not being found, set the `CHROME_BIN`
+environment variable to the path of your Chrome or Chromium binary, for example:
+
+~~~bash
+export CHROME_BIN=$(which google-chrome || which chromium-browser || which chromium)
+~~~
+
+This is required when running tests locally.
 
 ## lint and fix
 
@@ -45,7 +53,7 @@ This takes kanji list from Mext website, format them in JavaScript file to be im
 ## packaging
 
 ~~~
-$ yarn pack
+$ yarn run pack
 ~~~
 
 This only packs neccessary files for deployment on Extension stores. (currently for Chrome store)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "beautify": "eslint --fix scripts/*.js && stylelint --fix css/*.css",
     "check_firefox_compatibility": "wemf ./manifest.json --validate",
     "test": "karma start karma.conf.js",
-    "pack": "zip -r extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
+    "prepack": "zip -r extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
+    "pack": "yarn run prepack",
     "update_package_json": "node_modules/.bin/syncyarnlock -s -k"
   },
   "dependencies": {},


### PR DESCRIPTION
## Summary
- clarify that Karma needs the `CHROME_BIN` environment variable set

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*