### PR TITLE
Improve docs for local Karma tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: yarn test
       - name: Pack extension
-        run: yarn pack
+        run: yarn run pack
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ With this Chrome extension, when you show a web page, kanji are emphasized by it
 $ yarn test
 ~~~
 
+Before running this command locally, export `CHROME_BIN` to the path of your
+Chrome or Chromium executable:
+
+~~~
+$ export CHROME_BIN=$(which google-chrome)
+$ yarn test
+~~~
+
 The above command invokes Karma test runner. Karma auto-requires js modules (like as Chrome Extension env does) so test code can call them.
 
 Karma always comes with (headless) browser, which I do not use now. Test runner without client browser would fit better for this project but I could not find.
@@ -45,7 +53,7 @@ This takes kanji list from Mext website, format them in JavaScript file to be im
 ## packaging
 
 ~~~
-$ yarn pack
+$ yarn run pack
 ~~~
 
 This only packs neccessary files for deployment on Extension stores. (currently for Chrome store)
@@ -72,7 +80,8 @@ This extension is by MIT License
 
   * install [node](https://nodejs.org/en/)  (I recommend nvm for Windows)
   * install [yarn](https://yarnpkg.com/)
-  * 
+  * set `CHROME_BIN` to your local Chrome or Chromium executable before running
+    tests
 
 
 ## CI

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "beautify": "eslint --fix scripts/*.js && stylelint --fix css/*.css",
     "check_firefox_compatibility": "wemf ./manifest.json --validate",
     "test": "karma start karma.conf.js",
-    "pack": "zip -r extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
+    "prepack": "zip -r extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
+    "pack": "yarn run prepack",
     "update_package_json": "node_modules/.bin/syncyarnlock -s -k"
   },
   "dependencies": {},


### PR DESCRIPTION
## Summary
- document how to set `CHROME_BIN` when running tests locally

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*