### PR TITLE
Make highlighting opt-in via extension button

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,23 +10,13 @@
         "48": "icons/icon48.png",
         "128": "icons/icon128.png"
     },
-    "content_scripts": [
-        {
-            "matches": [
-                "*://*/*"
-            ],
-            "js": [
-                "data/elementary-kanji-array.js",
-                "data/elementary-kanji-json.js",
-                "scripts/findAndReplaceDOMText.js",
-                "scripts/replacer.js"
-            ],
-            "css": ["css/kanji_grades.css"],
-            "run_at": "document_end"
-        }
-    ],
+    "background": {
+        "service_worker": "scripts/background.js"
+    },
+    "action": {},
     "permissions": [
-        "activeTab"
+        "activeTab",
+        "scripting"
     ],
     "short_name": "ElmKanji"
 }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,0 +1,24 @@
+'use strict';
+
+chrome.action.onClicked.addListener(async (tab) => {
+    if (!tab.id) {
+        return;
+    }
+    try {
+        await chrome.scripting.insertCSS({
+            target: { tabId: tab.id },
+            files: ['css/kanji_grades.css']
+        });
+        await chrome.scripting.executeScript({
+            target: { tabId: tab.id },
+            files: [
+                'data/elementary-kanji-array.js',
+                'data/elementary-kanji-json.js',
+                'scripts/findAndReplaceDOMText.js',
+                'scripts/replacer.js'
+            ]
+        });
+    } catch (e) {
+        console.error(e);
+    }
+});


### PR DESCRIPTION
## Summary
- switch to service worker background script
- inject scripts and styles when the extension icon is clicked
- remove automatic content script execution

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*