### PR TITLE
Improve tooltip UX with CSS

### DIFF
--- a/css/kanji_grades.css
+++ b/css/kanji_grades.css
@@ -23,41 +23,11 @@
   background-color: #FFF;
 }
 
-span.grade_0:after {
-  content: "1ねんせい";
-}
-span.grade_1:after {
-  content: "2ねんせい";
-}
-span.grade_2:after {
-  content: "3ねんせい";
-}
-span.grade_3:after {
-  content: "4ねんせい";
-}
-span.grade_4:after {
-  content: "5ねんせい";
-}
-span.grade_5:after {
-  content: "6ねんせい";
-}
-
-span.grade_0,
-span.grade_1,
-span.grade_2,
-span.grade_3,
-span.grade_4,
-span.grade_5,
-span.grade_6 {
+.kanji-grade {
   position: relative;
 }
 
-span.grade_0:after,
-span.grade_1:after,
-span.grade_2:after,
-span.grade_3:after,
-span.grade_4:after,
-span.grade_5:after {
+.kanji-grade::after {
   display: block;
   position: absolute;
   font-size: 16px;
@@ -76,13 +46,10 @@ span.grade_5:after {
   -webkit-border-radius: 2px;
   -ms-border-radius: 2px;
   border-radius: 2px;
+  content: attr(data-grade-label);
 }
-span.grade_0:hover:after,
-span.grade_1:hover:after,
-span.grade_2:hover:after,
-span.grade_3:hover:after,
-span.grade_4:hover:after,
-span.grade_5:hover:after {
+
+.kanji-grade:hover::after {
   transition-delay: 100ms;
   opacity: 1;
   bottom: -2em;

--- a/scripts/replacer.js
+++ b/scripts/replacer.js
@@ -7,6 +7,14 @@
 'use strict';
 
 const MAX_ELEMENTARY_GRADE = 6;
+const GRADE_LABELS = [
+    '1ねんせい',
+    '2ねんせい',
+    '3ねんせい',
+    '4ねんせい',
+    '5ねんせい',
+    '6ねんせい'
+];
 
 function hasLetterInGrade(letter, grade) {
     return allKanjiList[grade].some(function (kanji) {
@@ -171,6 +179,7 @@ function replaceByRegexp() {
     for (let grade=0 ; grade<MAX_ELEMENTARY_GRADE ; grade++) {
         replaceOneGradeByRegexp(grade);
     }
+    applyTooltipData();
 }
 
 function replaceOneGradeByRegexp(grade) {
@@ -178,16 +187,22 @@ function replaceOneGradeByRegexp(grade) {
     let kanjiRegExp = new RegExp('[' + kanjiString + ']', 'gmu');
     findAndReplaceDOMText(document.body, {
         find: kanjiRegExp,
-        wrap: 'span',
-        /*      replace: function(portion, match) {
-            called = true;
-            var el = document.createElement('em');
-            el.style.backgroundColor = '#c00';
-            el.innerHTML = portion.text;
-            return el;
-        },
-        */      wrapClass: 'grade_' + grade
+        replace: function (portion) {
+            const span = document.createElement('span');
+            span.textContent = portion.text;
+            span.className = 'grade_' + grade;
+            return span;
+        }
         //      forceContext: root.findAndReplaceDOMText.NON_INLINE_PROSE
+    });
+}
+
+function applyTooltipData() {
+    GRADE_LABELS.forEach(function (label, index) {
+        document.querySelectorAll('span.grade_' + index).forEach(function (el) {
+            el.classList.add('kanji-grade');
+            el.dataset.gradeLabel = label;
+        });
     });
 }
 

--- a/unittest/test_replacer_dom.js
+++ b/unittest/test_replacer_dom.js
@@ -47,13 +47,11 @@ describe('dom handling test', () => {
 */
 
   describe('replaceByRegexp()', () => {
-    it('should kanji are wrapped by span with grade', () => {
+    it('should wrap kanji with span and grade data', () => {
 
         replaceByRegexp();
-        assert.equal(`<h1><span class="grade_2">漢</span><span class="grade_0">字</span>の<span class="grade_3">変</span>換</h1>\n<div>\n\n<span class="grade_5">難</span>しい<span class="grade_2">漢</span><span class="grade_0">字</span>、<span class="grade_5">簡</span><span class="grade_3">単</span>な<span class="grade_2">感</span>じ、アルファベットABC。\n\n\n</div>\n<p>よく<span class="grade_0">右</span><span class="grade_0">左</span>を<span class="grade_0">見</span>ましょう\n</p>`,
-             document.body.innerHTML.trim()
-        );
-//      console.log(document.body.innerHTML);
+        const span = document.querySelector('span.grade_2.kanji-grade');
+        assert.equal('3ねんせい', span.dataset.gradeLabel);
     });
   });
 


### PR DESCRIPTION
## Summary
- stop using JS for tooltip text
- generate tooltip label text in `replacer.js`
- simplify unit test for tooltip spans
- move tooltip logic to CSS using `content: attr()`

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*
