### PR TITLE
Fix release asset workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: ["master", "main"]
+    tags:
+      - 'v*'
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ It installs Chrome and sets `CHROME_BIN` so Karma can launch `ChromeHeadless`.
 The workflow also runs `yarn scrape` to fetch kanji data before tests.
 
 After a successful build, the packed extension zip is attached to a GitHub Release.
+The CI workflow runs when a tag starting with `v` is pushed and uploads `extension.zip` as a release asset.
 GitHub Releases are tagged using semantic versioning (v1.0.0, v1.0.1, ...) and include `extension.zip` for download.
 
 ## deployment


### PR DESCRIPTION
## Summary
- run CI when Git tags (v*) are pushed so that `extension.zip` is uploaded
- document tag-triggered release in README

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*