### PR TITLE
Resume artifact upload in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
         run: yarn test
       - name: Pack extension
         run: yarn run pack
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension
+          path: extension.zip
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ CI runs on GitHub Actions with the workflow defined at `.github/workflows/ci.yml
 It installs Chrome and sets `CHROME_BIN` so Karma can launch `ChromeHeadless`.
 The workflow also runs `yarn scrape` to fetch kanji data before tests.
 
-After a successful build, the packed extension zip is attached to a GitHub Release.
-The CI workflow runs when a tag starting with `v` is pushed and uploads `extension.zip` as a release asset.
+After a successful build, the packed extension zip is saved as a workflow artifact.
+When a tag starting with `v` is pushed, the workflow also attaches `extension.zip` to a GitHub Release.
 GitHub Releases are tagged using semantic versioning (v1.0.0, v1.0.1, ...) and include `extension.zip` for download.
 
 ## deployment


### PR DESCRIPTION
## Summary
- upload `extension.zip` as an artifact again
- document artifact upload in README

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*