### PR TITLE
Rename packaged zip file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: extension
-          path: extension.zip
+          path: elementary-kanji-extension.zip
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1
         with:
-          artifacts: extension.zip
+          artifacts: elementary-kanji-extension.zip
           tag: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           allowUpdates: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ yarn test
 Both commands should succeed. If the environment lacks network access and dependencies are missing, document this limitation in your PR message.
 
 ## Building
-To create a distribution package, run `yarn pack` after tests pass. This generates `extension.zip` for deployment.
+To create a distribution package, run `yarn pack` after tests pass. This generates `elementary-kanji-extension.zip` for deployment.
 
 ## Browser Compatibility
 Ensure the extension remains compatible with Manifest V3 for Chrome and with Firefox via `web-ext`. Use the latest stable Chrome Extension SDK and update build scripts when new versions are released. Do not remove existing tooling without discussion.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ It installs Chrome and sets `CHROME_BIN` so Karma can launch `ChromeHeadless`.
 The workflow also runs `yarn scrape` to fetch kanji data before tests.
 
 After a successful build, the packed extension zip is saved as a workflow artifact.
-When a tag starting with `v` is pushed, the workflow also attaches `extension.zip` to a GitHub Release.
-GitHub Releases are tagged using semantic versioning (v1.0.0, v1.0.1, ...) and include `extension.zip` for download.
+When a tag starting with `v` is pushed, the workflow also attaches `elementary-kanji-extension.zip` to a GitHub Release.
+GitHub Releases are tagged using semantic versioning (v1.0.0, v1.0.1, ...) and include `elementary-kanji-extension.zip` for download.
 
 ## deployment
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "beautify": "eslint --fix scripts/*.js && stylelint --fix css/*.css",
     "check_firefox_compatibility": "wemf ./manifest.json --validate",
     "test": "karma start karma.conf.js",
-    "pack": "zip -r extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
+    "pack": "zip -r elementary-kanji-extension.zip manifest.json scripts/*.js css/*.css data/*.js _locales icons/*.png",
     "update_package_json": "node_modules/.bin/syncyarnlock -s -k"
   },
   "dependencies": {},


### PR DESCRIPTION
## Summary
- rename generated zip file to `elementary-kanji-extension.zip`
- update workflow and docs with new file name

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*