### PR TITLE
Fix allKanjiStingArray typo

### DIFF
--- a/data/elementary-kanji-array.js
+++ b/data/elementary-kanji-array.js
@@ -1,4 +1,4 @@
-const allKanjiStingArray = [
+const allKanjiStringArray = [
   '字右左見',
   '',
   '漢感',

--- a/scripts/replacer.js
+++ b/scripts/replacer.js
@@ -1,7 +1,7 @@
 /*--- Eslint suppress ---*/
 /* eslint-disable no-unused-vars */
 /* global allKanjiList */
-/* global allKanjiStingArray */
+/* global allKanjiStringArray */
 /* global findAndReplaceDOMText */
 
 'use strict';
@@ -183,7 +183,7 @@ function replaceByRegexp() {
 }
 
 function replaceOneGradeByRegexp(grade) {
-    let kanjiString = allKanjiStingArray[grade];
+    let kanjiString = allKanjiStringArray[grade];
     let kanjiRegExp = new RegExp('[' + kanjiString + ']', 'gmu');
     findAndReplaceDOMText(document.body, {
         find: kanjiRegExp,

--- a/scripts/scraper/scraper.js
+++ b/scripts/scraper/scraper.js
@@ -61,16 +61,16 @@ function saveAsJavascriptArray(allKanjiList) {
 
 function saveAsJavascriptStringArray(allKanjiList) {
     let html = '';
-    let allKanjiStingArray = [];
+    let allKanjiStringArray = [];
     for (let i=0 ; i<6 ; i++) {
         let regexp = '';
         allKanjiList[i].forEach(function(value) {
             regexp += value;
         });
-        allKanjiStingArray[i] = regexp;
+        allKanjiStringArray[i] = regexp;
     }
 
-    fs.writeFile(JAVASCRIPT_STRING_ARRAY_FILENAME, 'const allKanjiStingArray = ' + JSON.stringify(allKanjiStingArray), function (err) {
+    fs.writeFile(JAVASCRIPT_STRING_ARRAY_FILENAME, 'const allKanjiStringArray = ' + JSON.stringify(allKanjiStringArray), function (err) {
         if (err) {
             return console.log(err);
         }


### PR DESCRIPTION
## Summary
- rename `allKanjiStingArray` to `allKanjiStringArray`
- update scraper, replacer, and data files

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6843dbfc7a6c83219eff5cbc6ed3c169