### PR TITLE
Fix stylelint plugin export

### DIFF
--- a/scripts/stylelint-stylistic.js
+++ b/scripts/stylelint-stylistic.js
@@ -31,7 +31,9 @@ for (const name of ruleNames) {
     const plugin = createNoopRule(fullName);
     plugin.ruleName = fullName;
     plugin.messages = stylelint.utils.ruleMessages(fullName, {});
+    plugin.meta = { url: 'https://github.com/stylelint/stylelint-stylistic' };
     rules[name] = plugin;
 }
 
 module.exports = { rules };
+module.exports.default = { rules };


### PR DESCRIPTION
## Summary
- add metadata and default export to `stylelint-stylistic` plugin

## Testing
- `yarn lint` *(fails: "This package doesn't seem to be present in your lockfile; run \"yarn install\" to update the lockfile")*
- `yarn test` *(fails: "This package doesn't seem to be present in your lockfile; run \"yarn install\" to update the lockfile")*

------
https://chatgpt.com/codex/tasks/task_e_684402a5319083218bc6ef041b4ede2b