### PR TITLE
Fix stylelint plugin pack

### DIFF
--- a/scripts/stylelint-stylistic.js
+++ b/scripts/stylelint-stylistic.js
@@ -25,13 +25,14 @@ const ruleNames = [
     'indentation'
 ];
 
-const rules = {};
-for (const name of ruleNames) {
+const plugins = ruleNames.map((name) => {
     const fullName = `stylistic/${name}`;
     const plugin = createNoopRule(fullName);
     plugin.ruleName = fullName;
     plugin.messages = stylelint.utils.ruleMessages(fullName, {});
-    rules[name] = plugin;
-}
+    plugin.meta = { url: 'https://github.com/stylelint/stylelint-stylistic' };
+    return plugin;
+});
 
-module.exports = { rules };
+module.exports = plugins;
+module.exports.default = plugins;


### PR DESCRIPTION
## Summary
- adjust local stylelint plugin to export an array of rule functions

## Testing
- `yarn lint` *(fails: "This package doesn't seem to be present in your lockfile; run \"yarn install\" to update the lockfile")*
- `yarn test` *(fails: "This package doesn't seem to be present in your lockfile; run \"yarn install\" to update the lockfile")*

------
https://chatgpt.com/codex/tasks/task_e_684402a5319083218bc6ef041b4ede2b