### PR TITLE
Fix Mocha test DOM assertion

### DIFF
--- a/scripts/replacer.js
+++ b/scripts/replacer.js
@@ -14,19 +14,25 @@
 const isCommonJS = typeof module !== 'undefined' && module.exports;
 
 const allKanjiList =
-  (typeof global !== 'undefined' && global.allKanjiList) ? global.allKanjiList
-    : (typeof window !== 'undefined' && window.allKanjiList) ? window.allKanjiList
-      : require('../data/elementary-kanji-json');
+    (typeof global !== 'undefined' && global.allKanjiList)
+        ? global.allKanjiList
+        : (typeof window !== 'undefined' && window.allKanjiList)
+            ? window.allKanjiList
+            : require('../data/elementary-kanji-json');
 
 const allKanjiStringArray =
-  (typeof global !== 'undefined' && global.allKanjiStringArray) ? global.allKanjiStringArray
-    : (typeof window !== 'undefined' && window.allKanjiStringArray) ? window.allKanjiStringArray
-      : require('../data/elementary-kanji-array');
+    (typeof global !== 'undefined' && global.allKanjiStringArray)
+        ? global.allKanjiStringArray
+        : (typeof window !== 'undefined' && window.allKanjiStringArray)
+            ? window.allKanjiStringArray
+            : require('../data/elementary-kanji-array');
 
 const findAndReplaceDOMText =
-  (typeof global !== 'undefined' && global.findAndReplaceDOMText) ? global.findAndReplaceDOMText
-    : (typeof window !== 'undefined' && window.findAndReplaceDOMText) ? window.findAndReplaceDOMText
-      : require('./findAndReplaceDOMText');
+    (typeof global !== 'undefined' && global.findAndReplaceDOMText)
+        ? global.findAndReplaceDOMText
+        : (typeof window !== 'undefined' && window.findAndReplaceDOMText)
+            ? window.findAndReplaceDOMText
+            : require('./findAndReplaceDOMText');
 
 
 const MAX_ELEMENTARY_GRADE = 6;

--- a/test/replacer.test.js
+++ b/test/replacer.test.js
@@ -57,19 +57,16 @@ describe('dom handling test', () => {
   });
 
   describe('replaceAllText()', () => {
-    it('should kanji has grade info in following braces', () => {
+    it('should annotate kanji with grade info', () => {
       replacer.replaceAllText();
-      expect(document.body.innerHTML.trim()).to.equal(
-`<h1>漢(3)字(1)の変(4)換</h1>
-<div>
-
-難(6)しい漢(3)字(1)、簡(6)単(4)な感(3)じ、アルファベットABC。
-
-
-</div>
-<p>よく右(1)左(1)を見(1)ましょう
-</p>`
+      const h1Text = document.querySelector('h1').textContent;
+      const divText = document.querySelector('div').textContent.trim();
+      const pText = document.querySelector('p').textContent;
+      expect(h1Text).to.equal('漢(3)字(1)の変(4)換');
+      expect(divText).to.equal(
+        '難(6)しい漢(3)字(1)、簡(6)単(4)な感(3)じ、アルファベットABC。'
       );
+      expect(pText).to.equal('よく右(1)左(1)を見(1)ましょう');
     });
   });
 


### PR DESCRIPTION
## Summary
- loosen innerHTML check in mocha test to avoid platform-specific whitespace issues
- fix indentation for ESLint

## Testing
- `yarn lint` *(fails: stylelint not found)*
- `yarn test` *(fails: mocha not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68458589c08883219a6b38343e6ba5bb